### PR TITLE
Undefined Enum entry is Undefined not Unknown

### DIFF
--- a/src/Plaid/Converters/EnumConverterFactory.cs
+++ b/src/Plaid/Converters/EnumConverterFactory.cs
@@ -66,7 +66,7 @@ public class EnumConverterFactory : JsonConverterFactory
 			}
 
 			// Plaid may return new/unknown values on parse. Don't crash at least...
-			return Enum.Parse<T>("Unknown");
+			return Enum.Parse<T>("Undefined");
 		}
 
 		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>


### PR DESCRIPTION
When Plaid add a new option (e.g. payment_status product) in an array this line should allow not crashing by returning the "Undefined" value on the enum - this looks like a typo of "Unknown" for "Undefined" (see e.g. Products enum)