### PR TITLE
Fix storage of AccessToken in GetAccessToken

### DIFF
--- a/tests/Plaid.Demo/Controllers/HomeController.cs
+++ b/tests/Plaid.Demo/Controllers/HomeController.cs
@@ -44,7 +44,7 @@ namespace Going.Plaid.Demo.Controllers
 				{
 					PublicToken = publicToken,
 				});
-			_credentials.AccessToken = result.ItemId;
+			_credentials.AccessToken = result.AccessToken;
 			System.Diagnostics.Debug.WriteLine($"access_token: '{result.AccessToken}'");
 
 			return Ok(result);


### PR DESCRIPTION
GetAccessToken stores the ItemId into _credentials.AccessToken upon receiving a token. This seems wrong. It's the AccessToken itself we'll want around for future requests.