### PR TITLE
Extend demo to include fetching transactions

### DIFF
--- a/tests/Plaid.Demo/Controllers/HomeController.cs
+++ b/tests/Plaid.Demo/Controllers/HomeController.cs
@@ -21,6 +21,23 @@ namespace Going.Plaid.Demo.Controllers
 		public IActionResult Index() =>
 			View(_credentials);
 
+		public async Task<IActionResult> Transactions()
+		{
+			_client.AccessToken = _credentials.AccessToken;
+			var request = new Transactions.TransactionsGetRequest()
+			{
+				Options = new TransactionsGetRequestOptions()
+				{
+					Count = 100
+				},
+				StartDate = DateTime.Now - TimeSpan.FromDays(30),
+				EndDate = DateTime.Now
+			};
+			var result = await _client.TransactionsGetAsync(request);
+
+			return View(result);
+		}
+
 		[HttpPost]
 		public async Task<IActionResult> GetLinkToken([FromBody] string[] products)
 		{
@@ -44,7 +61,7 @@ namespace Going.Plaid.Demo.Controllers
 				{
 					PublicToken = publicToken,
 				});
-			_credentials.AccessToken = result.ItemId;
+			_credentials.AccessToken = result.AccessToken;
 			System.Diagnostics.Debug.WriteLine($"access_token: '{result.AccessToken}'");
 
 			return Ok(result);

--- a/tests/Plaid.Demo/Views/Home/Index.cshtml
+++ b/tests/Plaid.Demo/Views/Home/Index.cshtml
@@ -10,11 +10,11 @@
             <hr />
  
             <div class="input" style="width: fit-content; margin: auto; text-align: right;">
-                @foreach (var product in Enum.GetNames(typeof(Going.Plaid.Entity.Products)))
+                @foreach (var product in new[] {"Assets", "Auth", "Identity", "Investments", "Liabilities", "Transactions", "Income" })
                 {
                     <label class="container">
                         @product
-                        <input class="product-box" type="checkbox" data-value="@product" />
+                        <input class="product-box" type="checkbox" checked data-value="@product" />
                         <span class="checkmark"></span>
                     </label>
                     <br/>
@@ -34,8 +34,11 @@
     </div>
 </div>
 
-<div id="plaid-products" class="row">
+<div id="plaid-products" data-bind="hidden: hideProducts" class="row">
     <div class="col-xs-12">
+        <h2 style="margin-top: 2rem">Products</h2>
+        <p>Now that you have an access_token, you can make the following requests:</p>
+        <a asp-action="Transactions">Transactions</a>
     </div>
 </div>
 
@@ -48,7 +51,8 @@
 
             self.environment = ko.observable("@Model.Environment");
             self.linkToken = ko.observable("@Model.LinkToken");
-            self.accessToken = ko.observable();
+            self.accessToken = ko.observable("@Model.AccessToken");
+            self.hideProducts = ko.observable(@(string.IsNullOrEmpty(Model.AccessToken)?"true":"false"));
 
             self.products = function () {
                 let transactions = [];
@@ -63,7 +67,7 @@
             };
 
             self.hasAccessToken = ko.observable(function () {
-                return self.isNullOrEmpty(this.accessToken);
+                return ! self.isNullOrEmpty(this.accessToken);
             }, this);
 
             self.isNullOrEmpty = function (text) {
@@ -106,6 +110,7 @@
                         });
 						const responseJSON = await response.json();
                         self.accessToken(responseJSON.access_token);
+                        self.hideProducts(false);
                     },
                     onExit: function (err, metadata) {
                         // The user exited the Link flow.
@@ -181,7 +186,6 @@
         (function () {
             vm = new ViewModel();
             ko.applyBindings(vm);
-            document.getElementsByClassName("product-box")[0].checked = true;
         })();
 	</script>
 }

--- a/tests/Plaid.Demo/Views/Home/Transactions.cshtml
+++ b/tests/Plaid.Demo/Views/Home/Transactions.cshtml
@@ -1,0 +1,13 @@
+@model Going.Plaid.Transactions.TransactionsGetResponse
+
+<h2>Transactions</h2>
+<table>
+    @foreach(var transaction in Model.Transactions)
+    {
+        <tr>
+            <td>@transaction.Name</td>
+            <td>@transaction.Amount.ToString("C2")</td>
+            <td>@transaction.Date.ToShortDateString()</td>
+        </tr>
+    }
+</table>


### PR DESCRIPTION
Hi, are you interested in having the demo call into some of the endpoints? I needed to do this anyway for my own understanding of the system, so I thought I'd offer it back if you wanted it.

Along the way, I made a few other changes:
* Removed products which will fail when sent to LinkTokenCreateAsync
* Check all (remaining) products by default
* Show/hide div#plaid-products if/when user has access_token
* Show access token on initial load of Home/Index if already exists
* Includes previous PR (wouldn't work otherwise)