### PR TITLE
Add LAST_UPDATED_DATETIME_OUT_OF_RANGE error code

### DIFF
--- a/src/Plaid/Entity/ErrorCode.cs
+++ b/src/Plaid/Entity/ErrorCode.cs
@@ -276,6 +276,13 @@ public enum ErrorCode
 	/// <remarks>This code is currently undocumented.</remarks>
 	[EnumMember(Value = "INVALID_CONFIGURATION")]
 	InvalidConfiguration,
+
+	/// <summary>
+	/// The balance that is pulled for ins_128026 (Capital One) is older than the given timestamp.
+	/// </summary>
+	/// <remarks><see href="https://plaid.com/docs/api/products/balance/#accounts-balance-get-request-options-min-last-updated-datetime"/></remarks>
+	[EnumMember(Value = "LAST_UPDATED_DATETIME_OUT_OF_RANGE")]
+	LastUpdatedDatetimeOutOfRange,
 	#endregion
 
 	#region INVALID_INPUT Codes


### PR DESCRIPTION
https://plaid.com/docs/api/products/balance/#accounts-balance-get-request-options-min-last-updated-datetime

This is a specific scenario with ins_128026 (Capital One), error code was missing.