### PR TITLE
regression on v4.21.0 that set FlowType back to non-nullable

### DIFF
--- a/src/Plaid/Entity/LinkTokenCreateRequestAuth.cs
+++ b/src/Plaid/Entity/LinkTokenCreateRequestAuth.cs
@@ -1,4 +1,4 @@
-namespace Going.Plaid.Entity;
+﻿namespace Going.Plaid.Entity;
 
 /// <summary>
 /// <para>Specifies options for initializing Link for use with the Auth product. This field can be used to enable or disable extended Auth flows for the resulting Link session. Omitting any field will result in a default that can be configured by your account manager.</para>
@@ -33,5 +33,5 @@ public class LinkTokenCreateRequestAuth
 	/// <para>This field has been deprecated in favor of <c>auth_type_select_enabled</c>.</para>
 	/// </summary>
 	[JsonPropertyName("flow_type")]
-	public Entity.LinkTokenCreateRequestAuthFlowTypeEnum FlowType { get; set; } = default!;
+	public Entity.LinkTokenCreateRequestAuthFlowTypeEnum? FlowType { get; set; } = default!;
 }


### PR DESCRIPTION
Resetting `FlowType` back to a nullable `LinkTokenCreateRequestAuthFlowTypeNum`, per the deprecation status of the `flow-type` property.  
Based on your comment here, I'm guessing enum was re-generated and overwrote the nullable attribute. https://github.com/viceroypenguin/Going.Plaid/issues/71#issuecomment-1173787511

https://plaid.com/docs/api/tokens/#link-token-create-request-auth-flow-type