### PR TITLE
Adding more versatile configuration method

### DIFF
--- a/src/Plaid/PlaidServiceCollectionExtensions.cs
+++ b/src/Plaid/PlaidServiceCollectionExtensions.cs
@@ -6,6 +6,23 @@
 public static class PlaidServiceCollectionExtensions
 {
 	/// <summary>
+	/// Registers and configures all of the Plaid infrastructure.
+	/// </summary>
+	/// <param name="services">The <see cref="IServiceCollection"/> to add the services to</param>
+	/// <param name="configure">A callback allowing for configuration of the <see cref="PlaidOptions"/></param>
+	/// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained</returns>
+	public static IServiceCollection AddPlaid(
+		this IServiceCollection services,
+		Action<OptionsBuilder<PlaidOptions>> configure)
+	{
+		var optionsBuilder = services.AddOptions<PlaidOptions>();
+		configure?.Invoke(optionsBuilder);
+		return services
+			.AddPlaidHttpClient()
+			.AddPlaidClient();
+	}
+
+	/// <summary>
 	/// Registers all of the Plaid infrastructure, including <see cref="PlaidOptions"/> 
 	/// configuration data stored in the <see cref="PlaidOptions.SectionKey"/> (<c>"Plaid"</c>)
 	/// section of the provided configuration root.
@@ -28,10 +45,7 @@ public static class PlaidServiceCollectionExtensions
 	public static IServiceCollection AddPlaid(
 		this IServiceCollection services,
 		IConfiguration configuration)
-		=> services
-			.Configure<PlaidOptions>(configuration)
-			.AddPlaidHttpClient()
-			.AddPlaidClient();
+		=> services.AddPlaid(opt => opt.Bind(configuration));
 
 	/// <summary>
 	/// Registers the <see cref="PlaidClient"/> as a singleton for use in the DI system.


### PR DESCRIPTION
Hello Going.Plaid contributors,

I wanted to extend your service collection extensions with a catch-all case, in case, as was my case, developers need to configure the library in any other ways than your standard bind to `IConfiguration`. This gives developers the power to configure their library in any way at all really, for example:
```csharp
services.AddPlaid(opt =>
{
  opt.Bind(configuration);
  opt.Configure((PlaidOptions opt, IKeyStore keyStore) =>
  {
    opt.Secret = keyStore.GetKey("PLAID_SECRET");
  });
});
```

Let me know!