### PR TITLE
CreditFundsSource nullable

### DIFF
--- a/src/Plaid/Entity/Transfer.cs
+++ b/src/Plaid/Entity/Transfer.cs
@@ -192,7 +192,7 @@ public record Transfer
 	/// <para><c>prefunded_ach_credits</c> - Use your prefunded ACH credit balance with Plaid</para>
 	/// </summary>
 	[JsonPropertyName("credit_funds_source")]
-	public Entity.TransferCreditFundsSource CreditFundsSource { get; init; } = default!;
+	public Entity.TransferCreditFundsSource? CreditFundsSource { get; init; } = default!;
 
 	/// <summary>
 	/// <para>The amount to deduct from <c>transfer.amount</c> and distribute to the platform’s Ledger balance as a facilitator fee (decimal string with two digits of precision e.g. "10.00"). The remainder will go to the end-customer’s Ledger balance. This must be less than or equal to the <c>transfer.amount</c>.</para>


### PR DESCRIPTION
`credit_funds_source` is nullable

After updating to 6.31.1 from 6.31.0, you will get an error: Expected a non-null enum value, found null.

refer to https://plaid.com/docs/api/products/transfer/reading-transfers/#transfer-get-response-transfer-credit-funds-source